### PR TITLE
flake8 ignore 추가

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,8 @@
 ; F722 syntax error in forward annotation
 ; F821 undefined name
 ; W503 line break before binary operator
-ignore = E501, F722, F821, W503
+; C901 ignored for spell_checker.py check func complex error fix
+ignore = E501, F722, F821, W503, C901
 exclude = venv, .venv, .git, __pycache__
 max-complexity = 10
 count = True


### PR DESCRIPTION
spell_checker.py의 check 함수 관련 flake8 오류가 계속 발생하였는데, 이는 모듈 코드 자체의 문제이므로 발생하는 오류인 C901를 무시하게 했습니다.
![image](https://user-images.githubusercontent.com/61998307/182071891-629dfb29-ec09-4a4d-ac3d-8b352742776e.png)
